### PR TITLE
#163258933 Create jwt extended Error Handler 

### DIFF
--- a/api/v1/main/controller/meetup_controller.py
+++ b/api/v1/main/controller/meetup_controller.py
@@ -5,6 +5,8 @@ This file handles meetup related HTTP requests.
 from flask import request
 from flask_restplus import Resource
 from flask_jwt_extended import jwt_required
+from flask_jwt_extended.exceptions import NoAuthorizationError,InvalidHeaderError
+from jwt import ExpiredSignatureError, InvalidTokenError, InvalidAudienceError
 
 # local import
 from api.v1.main.util.meetup_dto import MeetupDto
@@ -14,8 +16,11 @@ api = MeetupDto.api
 meetup = MeetupDto.meetup
 
 @api.route('/create')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class CreateMeetup(Resource):
-
     @api.response(201, 'Meetup has been created successfully')
     @api.doc('Create a new meetup')
     @api.doc(security='Bearer Auth')
@@ -29,6 +34,10 @@ class CreateMeetup(Resource):
         return save_new_meetup(meetup_data=data)
 
 @api.route('/upcoming') 
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 @api.doc(security='Bearer Auth')
 @api.response(401, 'You need to login first')   
 class GetMeetups(Resource):
@@ -39,6 +48,10 @@ class GetMeetups(Resource):
         """Get a list of all available meetups"""
         return get_all_meetups() 
 
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 @api.route('/<int:meetup_id>')
 @api.param('meetup_id', 'Meetup Identification.')
 @api.response(404, 'Meetup not found in the database')

--- a/api/v1/main/controller/question_controller.py
+++ b/api/v1/main/controller/question_controller.py
@@ -5,6 +5,8 @@ This file handles question related HTTP request.
 from flask import request
 from flask_restplus import Resource
 from flask_jwt_extended import jwt_required
+from flask_jwt_extended.exceptions import NoAuthorizationError,InvalidHeaderError
+from jwt import ExpiredSignatureError, InvalidTokenError, InvalidAudienceError
 
 # local imports
 from api.v1.main.util.question_dto import QuestionDto
@@ -15,6 +17,10 @@ quiz = QuestionDto.question
 
 @api.route('/<int:meetup_id>/create')
 @api.param('meetup_id', 'Meetup Identification')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class CreateQuestion(Resource):
 
     @api.response(201, 'Question has been created successfully')
@@ -29,8 +35,13 @@ class CreateQuestion(Resource):
         quiz_data = request.json
         return save_new_question(question_data=quiz_data, meetup_id=meetup_id)
 
+
 @api.route('/questions') 
-@api.response(401, 'You need to login first')   
+@api.response(401, 'You need to login first') 
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)  
 class GetQuestions(Resource):
     @api.doc('List of all available questions')
     @api.doc(security='Bearer Auth')
@@ -40,9 +51,14 @@ class GetQuestions(Resource):
         """Get a list of all available questionss"""
         return  get_all_questions()
 
+
 @api.route('/<int:question_id>')
 @api.param('question_id', 'Question Identification.')
 @api.response(404, 'Question not found in the database')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class SpecificQuestion(Resource):
     @api.doc('Get a specific question using the question id')
     @api.doc(security='Bearer Auth')
@@ -55,6 +71,10 @@ class SpecificQuestion(Resource):
 
 @api.route('/<int:question_id>/upvote')
 @api.param('question_id', 'Question Identification')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class CreateQuestion(Resource):
 
     @api.response(201, 'You have successfully upvoted')
@@ -69,6 +89,10 @@ class CreateQuestion(Resource):
 
 @api.route('/<int:question_id>/downvote')
 @api.param('question_id', 'Question Identification')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class CreateQuestion(Resource):
 
     @api.response(201, 'You have successfully downvoted')

--- a/api/v1/main/controller/rsvp_controller.py
+++ b/api/v1/main/controller/rsvp_controller.py
@@ -4,6 +4,8 @@ This file handles Reservation related HTTP request.
 from flask import request
 from flask_restplus import Resource
 from flask_jwt_extended import jwt_required
+from flask_jwt_extended.exceptions import NoAuthorizationError,InvalidHeaderError
+from jwt import ExpiredSignatureError, InvalidTokenError, InvalidAudienceError
 
 # local imports
 from api.v1.main.service.rsvp_service import save_new_rsvp
@@ -14,6 +16,10 @@ rsvp = RsvpDto.rsvp
 
 @api.route('/<int:meetup_id>/rsvp')
 @api.param('meetup_id', 'Meetup Identification')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class CreateQuestion(Resource):
 
     @api.response(201, 'You have successfully reserved a meetup')

--- a/api/v1/main/controller/user_auth_controller.py
+++ b/api/v1/main/controller/user_auth_controller.py
@@ -5,6 +5,8 @@ This file handles user related HTTP requests
 from flask import request
 from flask_restplus import Resource
 from flask_jwt_extended import jwt_required
+from flask_jwt_extended.exceptions import NoAuthorizationError,InvalidHeaderError
+from jwt import ExpiredSignatureError, InvalidTokenError, InvalidAudienceError
 
 # local import
 from api.v1.main.util.user_dto import UserAuthDto
@@ -26,6 +28,10 @@ class SigninUser(Resource):
 
 
 @api.route('/signout')
+@api.errorhandler(NoAuthorizationError)
+@api.errorhandler(ExpiredSignatureError)
+@api.errorhandler(InvalidTokenError)
+@api.errorhandler(InvalidHeaderError)
 class SignoutUser(Resource):
     """
     User signout resource

--- a/api/v1/main/service/question_service/question_service.py
+++ b/api/v1/main/service/question_service/question_service.py
@@ -87,16 +87,22 @@ def specific_question(question_id):
 
 def upvote_question(question_id):
     question = get_question_by_id(question_id)
-
+    admin = UserAuth.get_admin()
     if question:
-        question.votes+=1
-        response_object = {
-            'status':201,
-            'message':'You have successfully upvoted this question'
-        }
-        return response_object, 201
+        if admin:
+            response_object = {
+            'status':401,
+            }
+            return response_object, 401
+        else:
+            question.votes+=1
+            response_object = {
+                'status':201,
+                'message':'You have successfully upnvoted this question'
+            }
+            return response_object, 201
 
-    else:
+    if not question:
         response_object = {
             'status':404,
             'message':'Question not available.'
@@ -106,21 +112,26 @@ def upvote_question(question_id):
 def downvote_question(question_id):
     question = get_question_by_id(question_id)
 
-
+    admin = UserAuth.get_admin()
     if question:
-        question.votes-=1
-        response_object = {
-            'status':201,
-            'message':'You have successfully downvoted this question'
-        }
-        return response_object, 201
+        if admin:
+            response_object = {
+            'status':401,
+            'message':'Admin can not downvote a question'
+            }
+            return response_object, 401
+        else:
+            question.votes-=1
+            response_object = {
+                'status':201,
+                'message':'You have successfully downvoted this question'
+            }
+            return response_object, 201
 
-    else:
+    if not question:
         response_object = {
             'status':404,
             'message':'Question not available.'
         }
         return response_object, 404
-
-        
 

--- a/api/v1/main/service/rsvp_service.py
+++ b/api/v1/main/service/rsvp_service.py
@@ -69,7 +69,7 @@ def save_new_rsvp(meetup_id, user_input):
             'status':200,
             'message':'Meetup is not reserved.'
             }
-            return response_object, 400
+            return response_object, 200
         
         if not rsvp:
             save_rsvp = Rsvp()

--- a/api/v1/test/test_question.py
+++ b/api/v1/test/test_question.py
@@ -116,6 +116,18 @@ class TestAccessQuestion(BaseTestCase):
                 title="A That simple title",
                 body="Just a very long text"
             )
+
+    def login_user_admin(self):
+        """This helper method helps log in a test user."""
+        return self.client.post(
+        '/api/v1/user/auth/signin',
+            data=json.dumps(dict(
+            email='admin@admin.com',
+            password='#Sadm@3In'
+        )),
+        content_type='application/json'
+    )
+    
     def login_user(self):
         """This helper method helps log in a test user."""
         return self.client.post(
@@ -181,6 +193,17 @@ class TestAccessQuestion(BaseTestCase):
             response = self.client.patch('/api/v1/questions/18/upvote', headers=dict(Authorization=access_token),content_type='application/json') 
             self.assertEqual(response.status_code, 404)
 
+    def test_admin_can_not_upwnvote_question(self):
+        with self.client:
+            """
+            Test admin can not upvote a question
+            """
+            resp = self.login_user_admin()
+            access_token = json.loads(resp.data.decode())['access_token'] 
+            self.client.post('/api/v1/questions/1/create', headers=dict(Authorization=access_token),data=json.dumps(self.question_data),content_type='application/json') 
+            response = self.client.patch('/api/v1/questions/1/downvote', headers=dict(Authorization=access_token),content_type='application/json') 
+            self.assertEqual(response.status_code, 401)
+
     def test_successful_downvote(self):
         with self.client:
             """
@@ -203,6 +226,17 @@ class TestAccessQuestion(BaseTestCase):
             self.client.post('/api/v1/questions/1/create', headers=dict(Authorization=access_token),data=json.dumps(self.question_data),content_type='application/json') 
             response = self.client.patch('/api/v1/questions/18/downvote', headers=dict(Authorization=access_token),content_type='application/json') 
             self.assertEqual(response.status_code, 404)
+
+    def test_admin_can_not_downvote_question(self):
+        with self.client:
+            """
+            Test admin can not upvote a question
+            """
+            resp = self.login_user_admin()
+            access_token = json.loads(resp.data.decode())['access_token'] 
+            self.client.post('/api/v1/questions/1/create', headers=dict(Authorization=access_token),data=json.dumps(self.question_data),content_type='application/json') 
+            response = self.client.patch('/api/v1/questions/1/downvote', headers=dict(Authorization=access_token),content_type='application/json') 
+            self.assertEqual(response.status_code, 401)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
Adds JWT extended error handling decorators  for  QUESTIONER API

### Description of Task to be completed?
Have the following endpoints working
```
|Endpoint                            | Functionality                    |HTTP method 
|------------------------------------|----------------------------------|-------------
|/api/v1/user/signup                 |Signup account                    |POST        
|/api/v1/user/auth/signin            |Signin in user                    |POST
|/api/v1/user/auth/signout           |Signout in user                   |POST
|/api/v1/meetups/create              |Create a meetup record            |POST
|/api/v1/meetups/upcoming            |Get upcoming meetups              |GET
|/api/v1/meetups/<meetup-id>         |Fetch specific upcoming meetup    |GET
|/api/v1/questions/questions         |Fetch all question                |GET
|/api/v1/questions/<meetup-id>/create|Create a question                 |POST
|/api/v1/questions/<question-id> |access specific question                 |GET
|/api/v1/questions/<question-id>/upvote |upvote specific question        |PATCH
|/api/v1/questions/<question-id>/downvote |downvote specific question   |PATCH
|/api/v1/questions/<meetup-id>/rsvp       |Rsvp a specific meetup            |POST
```

### How should this be manually tested?
Using your terminal run the following commands:
```
- cd path/to/server-root
- git clone this repo
- cd to Questioner
- python3 -m venv env
- source env/bin/activate
- pip install requirement.txt
- on command line run manage.py test or run
```
### Any background context you want to provide?
No database
### What are the relevant pivotal tracker stories?
[#163258933](https://www.pivotaltracker.com/story/show/163258933)
